### PR TITLE
Simplify coherence update in semantics for fulfil and amo

### DIFF
--- a/src/shared/bir_quotationLib.sml
+++ b/src/shared/bir_quotationLib.sml
@@ -471,7 +471,7 @@ fun bir_program_parser obs_ty =
                ++ many stmt_parser
                ++ end_stmt_parser_finished)
                >> (fn (lbl,(stmts,end_stmt))
-                      => bblock obs_ty (lbl, stmts, end_stmt)))
+                      => bblock obs_ty (lbl, ``SOME <| mc_acq:= F; mc_rel:= F; mc_atomic:= F |>``, stmts, end_stmt)))
               inp
       fun prog_parser inp =
           (many block_parser >>
@@ -798,7 +798,7 @@ fun pp_stmt stmt =
 fun pp_prog prog =
     let val (block_list,_) = dest_list (dest_BirProgram prog)
         fun pp_block bl =
-            let val (lbl,stmts_tm,end_stmt) = dest_bir_block bl
+            let val (lbl, mc_tags, stmts_tm,end_stmt) = dest_bir_block bl
                 val (stmts,_) = dest_list stmts_tm;
             in
               PP.block INCONSISTENT 0 [

--- a/src/theory/bir/bir_programSyntax.sml
+++ b/src/theory/bir/bir_programSyntax.sml
@@ -130,11 +130,11 @@ fun dest_bir_block tm = let
   val (ty, l) = TypeBase.dest_record tm
   val _ = if is_bir_block_t_ty ty then () else fail()
   val lbl = Lib.assoc "bb_label" l
-  val mc_tags = Lib.assoc "bb_mc_tags" l
+  val mc_tags_opt = Lib.assoc1 "bb_mc_tags" l
   val stmts = Lib.assoc "bb_statements" l
   val last_stmt = Lib.assoc "bb_last_statement" l
 in
-  (lbl, mc_tags, stmts, last_stmt)
+  (lbl, if isSome mc_tags_opt then snd $ valOf mc_tags_opt else bir_mc_tags_NONE, stmts, last_stmt)
 end handle e => raise wrap_exn "dest_bir_block" e;
 
 val is_bir_block = can dest_bir_block;

--- a/src/theory/tools/promising/bir_promisingScript.sml
+++ b/src/theory/tools/promising/bir_promisingScript.sml
@@ -564,7 +564,7 @@ clstep p cid s M [] s')
              (if (acq /\ rel) then s.bst_v_Rel else 0))))))
    /\ v_wPost = t_w
    /\ MAX v_wPre (s.bst_coh l) < t_w
-
+   /\ t_r < t_w
    (* No writes to memory location between read and write *)
    /\ (!t'. t_r < t' /\ t' < t_w ==> mem_is_loc M t' l)
 

--- a/src/theory/tools/promising/bir_promisingScript.sml
+++ b/src/theory/tools/promising/bir_promisingScript.sml
@@ -513,9 +513,7 @@ clstep p cid s M [] s')
  /\ s' = s with <| bst_viewenv := new_viewenv;
                    bst_prom updated_by (FILTER (\t'. t' <> t));
                    bst_environ := new_env;
-                   bst_coh := (\lo. if lo = l
-                                    then MAX (s.bst_coh l) v_post
-                                    else s.bst_coh(lo));
+                   bst_coh     updated_by (l =+ v_post);
                    bst_v_wOld := MAX s.bst_v_wOld v_post;
                    bst_v_CAP := MAX s.bst_v_CAP v_addr;
                    bst_v_Rel := MAX s.bst_v_Rel (if (rel /\ acq) then v_post else 0);
@@ -574,7 +572,7 @@ clstep p cid s M [] s')
    /\ s' = s with <| bst_viewenv := new_viewenv;
                      bst_environ := new_environ;
                      bst_prom    updated_by (FILTER (\t'. t' <> t_w));
-                     bst_coh     updated_by (l =+ MAX (s.bst_coh l) v_wPost);
+                     bst_coh     updated_by (l =+ v_wPost);
                      bst_v_Rel   updated_by (MAX (if acq /\ rel then v_wPost else 0));
                      bst_v_rOld  updated_by (MAX v_rPost);
                      bst_v_rNew  updated_by (MAX (if acq then (if rel then v_wPost else v_rPost)else 0));

--- a/src/tools/comp/examples/test-bir_populate_blacklist_predset.sml
+++ b/src/tools/comp/examples/test-bir_populate_blacklist_predset.sml
@@ -6,10 +6,10 @@ open bir_bool_expTheory;
 val observe_type = Type `: 'a`
 val bdefprog_list = bdefprog_list observe_type
 
-val p_def = bdefprog_list "p" [(blabel_str "entry", [], (bjmp o belabel_str) "0w"),
-                               (blabel_str "0w", [], (bjmp o belabel_str) "1w"),
-                               (blabel_str "1w", [], (bjmp o belabel_addr64) 2),
-                               (blabel_addr64 2, [], (bhalt o bconst64) 0)]
+val p_def = bdefprog_list "p" [(blabel_str "entry", bmc_none, [], (bjmp o belabel_str) "0w"),
+                               (blabel_str "0w", bmc_none, [], (bjmp o belabel_str) "1w"),
+                               (blabel_str "1w", bmc_none, [], (bjmp o belabel_addr64) 2),
+                               (blabel_addr64 2, bmc_none, [], (bhalt o bconst64) 0)]
 
 val post = ``(\l. if (l = BL_Address (Imm64 2w)) then bir_exp_true else bir_exp_false)``
 val c = prove(

--- a/src/tools/scamv/obsmodel/bir_obs_modelLib.sml
+++ b/src/tools/scamv/obsmodel/bir_obs_modelLib.sml
@@ -129,7 +129,7 @@ open bir_cfgLib;
           fun extract_stmts_from_lbl lbl =
               let open bir_programSyntax;
                   val block = Redblackmap.find (bl_dict, lbl)
-                  val (_, statements, _) = dest_bir_block block;
+                  val (_, _, statements, _) = dest_bir_block block;
                   (* statements is a HOL list of BIR statements *)
               in statements end;
 


### PR DESCRIPTION
The fulfil rule contains the conjuncts

    v_pre ⊔ ts.coh l < t  and  v_post = t

which simplifies the coherence update from

    ts'.coh l := ts.coh l ⊔ v_post

to

    ts'.coh l := v_post