### PR TITLE
Multicore syntax revision

### DIFF
--- a/src/shared/examples/test-bsl-progs.sml
+++ b/src/shared/examples/test-bsl-progs.sml
@@ -39,12 +39,12 @@ val tests = [
     ``BirProgram [
         <|bb_label := BL_Label "prologue";
           bb_mc_tags := NONE;
-          bb_statements := [];
+          bb_statements := [] : ('a bir_stmt_basic_t) list;
           bb_last_statement := BStmt_Jmp (BLE_Label (BL_Label "epilogue"))
         |>;
         <|bb_label := BL_Label "epilogue";
           bb_mc_tags := NONE;
-          bb_statements := [];
+          bb_statements := []: ('a bir_stmt_basic_t) list;
           bb_last_statement := BStmt_Halt (BExp_Const (Imm32 0w))
         |>
       ]``),

--- a/src/theory/bir-support/bir_program_multistep_propsScript.sml
+++ b/src/theory/bir-support/bir_program_multistep_propsScript.sml
@@ -389,53 +389,48 @@ METIS_TAC[FINITE_bir_exec_infinite_steps_fun_PC_COND_SET, prim_recTheory.LESS_SU
    The most important special case is that we count every beginning of blocks. Since
    all blocks are finite, we can only loop, if we execute infinitely many blocks. *)
 
-val bir_exec_infinite_steps_fun_block_starts_at_front = store_thm (
-  "bir_exec_infinite_steps_fun_block_starts_at_front",
-``!p st n st_n i.
+Theorem bir_exec_infinite_steps_fun_block_starts_at_front:
+  !p st n st_n i.
      (st_n = bir_exec_infinite_steps_fun p st n) ==>
      ((bir_exec_infinite_steps_fun p st n).bst_pc.bpc_index = i) ==>
      ~(bir_state_is_terminated st_n) ==>
      (i <= n) ==>
-
      ((bir_exec_infinite_steps_fun p st (n-i)).bst_pc =
-      (st_n.bst_pc with bpc_index := 0))``,
-
-GEN_TAC >> GEN_TAC >>
-Induct_on `i` >- (
-  SIMP_TAC (std_ss++bir_TYPES_ss) [bir_programTheory.bir_programcounter_t_component_equality]
-) >>
-
-FULL_SIMP_TAC std_ss [] >>
-REPEAT STRIP_TAC >>
-Cases_on `n` >> FULL_SIMP_TAC std_ss [] >>
-rename1 `i <= n'` >>
-Q.ABBREV_TAC `st_n' = (bir_exec_infinite_steps_fun p st n')` >>
-Q.PAT_X_ASSUM `!n'. _` (MP_TAC o Q.SPEC `n'`) >>
-FULL_SIMP_TAC std_ss [bir_exec_infinite_steps_fun_REWRS2] >>
-
-Cases_on `bir_state_is_terminated st_n'` >- (
-  FULL_SIMP_TAC std_ss [bir_exec_step_state_def, bir_exec_step_def]
-) >>
-
-Tactical.REVERSE (Cases_on `bir_is_valid_pc p st_n'.bst_pc`) >- (
-  FULL_SIMP_TAC (std_ss++bir_TYPES_ss) [bir_exec_step_state_def, bir_exec_step_def,
-    GSYM bir_get_current_statement_IS_SOME, bir_state_set_failed_def,
-    bir_state_is_terminated_def]
-) >>
-MP_TAC (Q.SPECL [`p`, `st_n'`] bir_exec_step_state_valid_THM) >>
-ASM_SIMP_TAC std_ss [] >>
-STRIP_TAC >>
-Tactical.REVERSE (Cases_on `stmt`) >- (
-  FULL_SIMP_TAC arith_ss [bir_exec_stmt_state_REWRS, bir_exec_stmtE_block_pc]
-) >>
-
-FULL_SIMP_TAC std_ss [bir_exec_stmt_state_REWRS, LET_DEF] >>
-Cases_on `bir_state_is_terminated (bir_exec_stmtB_state b st_n')` >> (
-  FULL_SIMP_TAC std_ss []
-) >>
-FULL_SIMP_TAC (std_ss++bir_TYPES_ss) [bir_pc_next_def,
-  bir_exec_stmtB_pc_unchanged]);
-
+      (st_n.bst_pc with bpc_index := 0))
+Proof
+  GEN_TAC >> GEN_TAC >>
+  Induct_on `i` >- (
+    SIMP_TAC (std_ss++bir_TYPES_ss) [bir_programTheory.bir_programcounter_t_component_equality]
+  ) >>
+  FULL_SIMP_TAC std_ss [] >>
+  REPEAT STRIP_TAC >>
+  Cases_on `n` >> FULL_SIMP_TAC std_ss [] >>
+  rename1 `i <= n'` >>
+  Q.ABBREV_TAC `st_n' = (bir_exec_infinite_steps_fun p st n')` >>
+  Q.PAT_X_ASSUM `!n'. _` (MP_TAC o Q.SPEC `n'`) >>
+  FULL_SIMP_TAC std_ss [bir_exec_infinite_steps_fun_REWRS2] >>
+  Cases_on `bir_state_is_terminated st_n'` >- (
+    FULL_SIMP_TAC std_ss [bir_exec_step_state_def, bir_exec_step_def]
+  ) >>
+  Tactical.REVERSE (Cases_on `bir_is_valid_pc p st_n'.bst_pc`) >- (
+    FULL_SIMP_TAC (std_ss++bir_TYPES_ss) [bir_exec_step_state_def, bir_exec_step_def,
+      GSYM bir_get_current_statement_IS_SOME, bir_state_set_failed_def,
+      bir_state_is_terminated_def]
+  ) >>
+  MP_TAC (Q.SPECL [`p`, `st_n'`] bir_exec_step_state_valid_THM) >>
+  drule_then assume_tac bir_exec_step_state_valid_THM >>
+  gs[] >>
+  Tactical.REVERSE (Cases_on `stmt`) >- (
+    FULL_SIMP_TAC arith_ss [bir_exec_stmt_state_REWRS, bir_exec_stmtE_block_pc]
+  ) >>
+  FULL_SIMP_TAC std_ss [bir_exec_stmt_state_REWRS, LET_DEF] >>
+  qmatch_goalsub_rename_tac `bir_exec_stmtB_state b st_n'` >>
+  Cases_on `bir_state_is_terminated (bir_exec_stmtB_state b st_n')` >> (
+    FULL_SIMP_TAC std_ss []
+  ) >>
+  FULL_SIMP_TAC (std_ss++bir_TYPES_ss) [bir_pc_next_def,
+    bir_exec_stmtB_pc_unchanged]
+QED
 
 
 val bir_is_valid_pc_FINITE = store_thm ("bir_is_valid_pc_FINITE",

--- a/src/theory/bir-support/bir_program_no_assumeScript.sml
+++ b/src/theory/bir-support/bir_program_no_assumeScript.sml
@@ -223,13 +223,13 @@ val bir_exec_stmtE_not_assumviol =
   ]
 );
 
-val bir_block_not_assume_never_assumviol =
-  store_thm ("bir_block_not_assume_never_assumviol",
-  ``!prog bl st l' c' st'.
+Theorem bir_block_not_assume_never_assumviol:
+  !prog bl st l' c' st'.
     bir_block_has_no_assumes bl ==>
     (st.bst_status <> BST_AssumptionViolated) ==>
     (bir_exec_block prog bl st = (l', c', st')) ==>
-    (st'.bst_status <> BST_AssumptionViolated)``,
+    (st'.bst_status <> BST_AssumptionViolated)
+Proof
   FULL_SIMP_TAC std_ss [bir_block_has_no_assumes_def,
                         bir_exec_block_def] >>
   REPEAT STRIP_TAC >>
@@ -240,15 +240,12 @@ val bir_block_not_assume_never_assumviol =
     FULL_SIMP_TAC std_ss [bir_exec_stmtsB_exists]
   ) >>
   FULL_SIMP_TAC std_ss [LET_DEF] >>
-  PAT_X_ASSUM ``!st' l' l c' c. _``
-          (fn thm => ASSUME_TAC
-            (SPECL [``st'_test:bir_state_t``,
-                ``l_test: (num # 'a) list``,
-                        ``[]: (num # 'a) list``,
-                ``c_test:num``,
-                ``0:num``] thm
-            )
-          ) >>
+  PAT_X_ASSUM ``!st' l' l c' c. _`` $
+            Q.SPECL_THEN [`st'_test:bir_state_t`,
+                `l_test: (num # 'a) list`,
+                        `[]: (num # 'a) list`,
+                `c_test:num`,
+                `0:num`] assume_tac >>
   REV_FULL_SIMP_TAC std_ss [] >>
   Cases_on `bir_state_is_terminated st'_test` >| [
     Cases_on `st'_test` >>
@@ -266,11 +263,11 @@ val bir_block_not_assume_never_assumviol =
                    st'_test)` >> (
       FULL_SIMP_TAC (std_ss++holBACore_ss) [] >>
       Cases_on `st'` >>
-      ASSUME_TAC (SPECL [``prog:'a bir_program_t``,
-                         ``bl.bb_last_statement:bir_stmt_end_t``,
-                         ``st'_test:bir_state_t``]
-                        bir_exec_stmtE_not_assumviol
-                 ) >>
+      Q.SPECL_THEN [`prog:'a bir_program_t`,
+                         `bl.bb_last_statement:bir_stmt_end_t`,
+                         `st'_test:bir_state_t`] assume_tac
+                  $ INST_TYPE [``:'a`` |-> ``:'a bir_stmt_basic_t``]
+                        bir_exec_stmtE_not_assumviol >>
       Q.ABBREV_TAC `st' = bir_exec_stmtE prog bl.bb_last_statement
                                          st'_test` >>
       Cases_on `st'` >>
@@ -278,7 +275,7 @@ val bir_block_not_assume_never_assumviol =
                         [bir_state_t_fn_updates]
     )
   ]
-);
+QED
 
 val bir_prog_has_no_assumes_def = Define `
   (bir_prog_has_no_assumes (BirProgram []) = T) /\

--- a/src/theory/bir-support/bir_program_valid_stateScript.sml
+++ b/src/theory/bir-support/bir_program_valid_stateScript.sml
@@ -20,17 +20,17 @@ val bir_is_valid_program_def = Define `bir_is_valid_program p <=>
 
 
 (* This allows some nice rewrites *)
-val bir_is_valid_labels_blocks_EQ_EL = store_thm ("bir_is_valid_labels_blocks_EQ_EL",
-  ``!p n1 n2. (bir_is_valid_labels (BirProgram p) /\ n1 < LENGTH p /\ n2 < LENGTH p /\
-                ((EL n1 p).bb_label = (EL n2 p).bb_label)) ==> (n1 = n2)``,
-
-SIMP_TAC list_ss [bir_is_valid_labels_def, bir_labels_of_program_def] >>
-REPEAT STRIP_TAC >>
-MP_TAC (Q.ISPEC `MAP (\bl. bl.bb_label) (p:('a bir_block_t) list)` listTheory.EL_ALL_DISTINCT_EL_EQ) >>
-ASM_SIMP_TAC list_ss [GSYM LEFT_EXISTS_IMP_THM] >>
-Q.EXISTS_TAC `n1` >> Q.EXISTS_TAC `n2` >>
-ASM_SIMP_TAC list_ss [listTheory.EL_MAP]);
-
+Theorem bir_is_valid_labels_blocks_EQ_EL:
+  !p n1 n2. (bir_is_valid_labels (BirProgram p) /\ n1 < LENGTH p /\ n2 < LENGTH p /\
+                ((EL n1 p).bb_label = (EL n2 p).bb_label)) ==> (n1 = n2)
+Proof
+  SIMP_TAC list_ss [bir_is_valid_labels_def, bir_labels_of_program_def] >>
+  REPEAT STRIP_TAC >>
+  MP_TAC (Q.ISPEC `MAP (\bl. bl.bb_label) (p:('a bir_generic_block_t) list)` listTheory.EL_ALL_DISTINCT_EL_EQ) >>
+  ASM_SIMP_TAC list_ss [GSYM LEFT_EXISTS_IMP_THM] >>
+  Q.EXISTS_TAC `n1` >> Q.EXISTS_TAC `n2` >>
+  ASM_SIMP_TAC list_ss [listTheory.EL_MAP]
+QED
 
 val bir_is_valid_labels_blocks_EQ = store_thm ("bir_is_valid_labels_blocks_EQ",
   ``!p bl1 bl2. (bir_is_valid_labels (BirProgram p) /\ MEM bl1 p /\ MEM bl2 p /\

--- a/src/theory/bir-support/bir_program_valid_stateScript.sml
+++ b/src/theory/bir-support/bir_program_valid_stateScript.sml
@@ -1,7 +1,7 @@
 open HolKernel Parse boolLib bossLib;
 open bir_auxiliaryTheory
 open bir_envTheory bir_valuesTheory
-open bir_programTheory HolBACoreSimps;
+open bir_programTheory HolBACoreSimps bir_init_progTheory;
 
 val _ = new_theory "bir_program_valid_state";
 

--- a/src/theory/bir-support/bir_update_blockScript.sml
+++ b/src/theory/bir-support/bir_update_blockScript.sml
@@ -1130,7 +1130,7 @@ val bir_update_assert_block_def = Define `bir_update_assert_block l al eup updat
 val bir_update_assert_block_ALT_def = store_thm ("bir_update_assert_block_ALT_def",
   ``((bir_update_assert_block l al eup updates):'a bir_block_t) =
     (bir_update_block l eup updates):'a bir_block_t with bb_statements := (bir_assert_block al ++ (bir_update_block l eup updates).bb_statements)``,
-SIMP_TAC (list_ss++bir_TYPES_ss) [bir_update_assert_block_def, bir_update_block_def, bir_block_t_component_equality]);
+SIMP_TAC (list_ss++bir_TYPES_ss) [bir_update_assert_block_def, bir_update_block_def, bir_generic_block_t_component_equality]);
 
 
 val bir_update_assert_block_SEM =

--- a/src/theory/bir/HolBACoreSimps.sml
+++ b/src/theory/bir/HolBACoreSimps.sml
@@ -28,16 +28,16 @@ val bir_list_of_types = [
    mk_thy_type {Tyop="bir_label_exp_t",      Thy="bir_program", Args=[]},
    mk_thy_type {Tyop="bir_stmt_end_t",       Thy="bir_program", Args=[]},
    mk_thy_type {Tyop="bir_stmt_basic_t",     Thy="bir_program", Args=[Type.alpha]},
-   mk_thy_type {Tyop="bir_stmt_t",           Thy="bir_program", Args=[Type.alpha]},
-   mk_thy_type {Tyop="bir_block_t",          Thy="bir_program", Args=[Type.alpha]},
-   mk_thy_type {Tyop="bir_program_t",        Thy="bir_program", Args=[Type.alpha]},
+   mk_thy_type {Tyop="bmc_stmt_basic_t",     Thy="bir_program", Args=[]},
+   mk_thy_type {Tyop="bir_generic_stmt_t",   Thy="bir_program", Args=[Type.alpha]},
+   mk_thy_type {Tyop="bir_generic_block_t",  Thy="bir_program", Args=[Type.alpha]},
+   mk_thy_type {Tyop="bir_generic_program_t",Thy="bir_program", Args=[Type.alpha]},
    mk_thy_type {Tyop="bir_programcounter_t", Thy="bir_program", Args=[]},
    mk_thy_type {Tyop="bir_status_t",         Thy="bir_program", Args=[]},
    mk_thy_type {Tyop="bir_inflight_stmt_t",  Thy="bir_program", Args=[Type.alpha]},
    mk_thy_type {Tyop="bir_state_t",          Thy="bir_program", Args=[]},
    mk_thy_type {Tyop="bir_execution_result_t", Thy="bir_program", Args=[Type.alpha]}
 ];
-
 
 val bir_TYPES_thms = (flatten (map type_rws bir_list_of_types));
 

--- a/src/theory/bir/bir_init_progScript.sml
+++ b/src/theory/bir/bir_init_progScript.sml
@@ -1,0 +1,52 @@
+(*
+  defines an initial state of a program
+*)
+
+open HolKernel Parse boolLib bossLib;
+open bir_typing_progTheory bir_programTheory;
+
+val _ = new_theory "bir_init_prog";
+
+Definition bir_state_init_def:
+  bir_state_init p = <|
+    bst_pc       := bir_pc_first p
+  ; bst_environ  := bir_env_default $ bir_envty_of_vs $ bir_vars_of_program p
+  ; bst_status := BST_Running
+  ; bst_viewenv := FEMPTY
+  ; bst_coh := \x.0
+  ; bst_v_rOld := 0
+  ; bst_v_CAP := 0
+  ; bst_v_rNew := 0
+  ; bst_v_wNew := 0
+  ; bst_v_wOld := 0
+  ; bst_v_Rel := 0
+  ; bst_prom := []
+  ; bst_inflight := []
+  ; bst_counter := 0
+  ; bst_fwdb := (\l. <| fwdb_time:= 0; fwdb_view:=0; fwdb_xcl:=F |>)
+  ; bst_xclb := NONE
+  |>
+End
+
+Definition bmc_state_init_def:
+  bmc_state_init p = <|
+      bst_pc       := bir_pc_first p
+    ; bst_environ  := bir_env_default $ bir_envty_of_vs $ bmc_vars_of_program p
+    ; bst_status := BST_Running
+    ; bst_viewenv := FEMPTY
+    ; bst_coh := \x.0
+    ; bst_v_rOld := 0
+    ; bst_v_CAP := 0
+    ; bst_v_rNew := 0
+    ; bst_v_wNew := 0
+    ; bst_v_wOld := 0
+    ; bst_v_Rel := 0
+    ; bst_prom := []
+    ; bst_inflight := []
+    ; bst_counter := 0
+    ; bst_fwdb := (\l. <| fwdb_time:= 0; fwdb_view:=0; fwdb_xcl:=F |>)
+    ; bst_xclb := NONE
+  |>
+End
+
+val _ = export_theory();

--- a/src/theory/bir/bir_programScript.sml
+++ b/src/theory/bir/bir_programScript.sml
@@ -192,14 +192,6 @@ val bir_stmt_ss = rewrites ((type_rws ``:'a bir_stmt_t``) @ (type_rws ``:bir_stm
 val bir_labels_of_program_def = Define `bir_labels_of_program (BirProgram p) =
   MAP (\bl. bl.bb_label) p`;
 
-val bir_varset_of_program_def =  Define `bir_varset_of_program (BirProgram p) =
-FOLDR (\a b. a UNION b) {}
-  (MAP (\bl. FOLDR (\a b. a UNION b) {}
-        (MAP bir_varset_of_basic_stmt bl.bb_statements)
-        UNION bir_varset_of_end_stmt bl.bb_last_statement)
-        p)
-`;
-
 val bir_get_program_block_info_by_label_def = Define `bir_get_program_block_info_by_label
   (BirProgram p) l = INDEX_FIND 0 (\ x. x.bb_label = l) p
 `;
@@ -273,25 +265,6 @@ val bir_state_set_typeerror_def = Define `bir_state_set_typeerror st =
   (st with bst_status := BST_TypeError)`;
 val bir_state_set_failed_def = Define `bir_state_set_failed st =
   (st with bst_status := BST_Failed)`;
-
-val bir_state_init_def = Define `bir_state_init p = <|
-    bst_pc       := bir_pc_first p
-  ; bst_environ  := bir_env_default (bir_envty_of_vs (bir_varset_of_program p))
-  ; bst_status := BST_Running
-  ; bst_viewenv := FEMPTY
-  ; bst_coh := \x.0
-  ; bst_v_rOld := 0
-  ; bst_v_CAP := 0
-  ; bst_v_rNew := 0
-  ; bst_v_wNew := 0
-  ; bst_v_wOld := 0
-  ; bst_v_Rel := 0
-  ; bst_prom := []
-  ; bst_inflight := []
-  ; bst_counter := 0
-  ; bst_fwdb := (\l. <| fwdb_time:= 0; fwdb_view:=0; fwdb_xcl:=F |>)
-  ; bst_xclb := NONE
-|>`;
 
 (* ------------------------------------------------------------------------- *)
 (*  Semantics of statements                                                  *)

--- a/src/theory/bir/bir_programSyntax.sml
+++ b/src/theory/bir/bir_programSyntax.sml
@@ -78,12 +78,17 @@ val (BStmt_Halt_tm,  mk_BStmt_Halt, dest_BStmt_Halt, is_BStmt_Halt)  = syntax_fn
 
 (* bir_stmt_t *)
 
-fun mk_bir_stmt_t_ty ty = mk_type ("bir_stmt_t", [ty]);
+fun mk_bir_stmt_t_ty ty =
+  mk_type("bir_generic_stmt_t", [mk_type("bir_stmt_basic_t",[ty])]);
 
 fun dest_bir_stmt_t_ty ty =
    case total dest_thy_type ty
-    of SOME {Tyop="bir_stmt_t", Thy="bir_program", Args=[ty]} => ty
-     | other => raise ERR "dest_bir_stmt_t_ty" ""
+    of SOME {Tyop="bir_generic_stmt_t", Thy="bir_program", Args=[ty]}
+    => (case total dest_thy_type ty
+      of SOME {Tyop="bir_stmt_basic_t", Thy="bir_program", Args=[ty]}
+      => ty
+      | other => raise ERR "dest_bir_stmt_t_ty" "")
+    | other => raise ERR "dest_bir_stmt_t_ty" ""
 
 val is_bir_stmt_t_ty = can dest_bir_stmt_t_ty;
 
@@ -117,11 +122,16 @@ val bir_mc_tags_NONE = optionSyntax.mk_none bir_mc_tags_t_ty;
 
 (* bir_block_t *)
 
-fun mk_bir_block_t_ty ty = mk_type ("bir_block_t", [ty]);
+fun mk_bir_block_t_ty ty =
+  mk_type("bir_generic_block_t", [mk_type("bir_stmt_basic_t",[ty])]);
 
 fun dest_bir_block_t_ty ty =
    case total dest_thy_type ty
-    of SOME {Tyop="bir_block_t", Thy="bir_program", Args=[ty]} => ty
+    of SOME {Tyop="bir_generic_block_t", Thy="bir_program", Args=[ty]} =>
+      (case total dest_thy_type ty
+      of SOME {Tyop="bir_stmt_basic_t", Thy="bir_program", Args=[ty]} =>
+        ty
+      | other => raise ERR "dest_bir_block_t_ty" "")
      | other => raise ERR "dest_bir_block_t_ty" ""
 
 val is_bir_block_t_ty = can dest_bir_block_t_ty;
@@ -169,11 +179,15 @@ end handle e => raise wrap_exn "mk_bir_block_list" e;
 
 (* bir_program_t *)
 
-fun mk_bir_program_t_ty ty = mk_type ("bir_program_t", [ty]);
+fun mk_bir_program_t_ty ty =
+  mk_type ("bir_generic_program_t", [mk_type ("bir_stmt_basic_t", [ty])]);
 
 fun dest_bir_program_t_ty ty =
    case total dest_thy_type ty
-    of SOME {Tyop="bir_program_t", Thy="bir_program", Args=[ty]} => ty
+    of SOME {Tyop="bir_generic_program_t", Thy="bir_program", Args=[ty]} => 
+      (case total dest_thy_type ty
+        of SOME {Tyop="bir_stmt_basic_t", Thy="bir_program", Args=[ty]} => ty
+        | other => raise ERR "dest_bir_program_t_ty" "")
      | other => raise ERR "dest_bir_program_t_ty" ""
 
 val is_bir_program_t_ty = can dest_bir_program_t_ty;

--- a/src/theory/bir/bir_programSyntax.sml
+++ b/src/theory/bir/bir_programSyntax.sml
@@ -2,7 +2,7 @@ structure bir_programSyntax :> bir_programSyntax =
 struct
 
 open HolKernel boolLib liteLib simpLib Parse bossLib;
-open bir_immTheory bir_valuesTheory bir_programTheory;
+open bir_immTheory bir_valuesTheory bir_programTheory bir_init_progTheory;
 
 
 val ERR = mk_HOL_ERR "bir_programSyntax"
@@ -300,7 +300,8 @@ val (bst_environ_tm,  mk_bst_environ, dest_bst_environ, is_bst_environ)  = synta
 val (bst_pc_tm,  mk_bst_pc, dest_bst_pc, is_bst_pc)  = syntax_fns1 "bir_state_t_bst_pc";
 
 
-val (bir_state_init_tm,  mk_bir_state_init, dest_bir_state_init, is_bir_state_init)  = syntax_fns1 "bir_state_init";
+val (bir_state_init_tm,  mk_bir_state_init, dest_bir_state_init, is_bir_state_init)  =
+  HolKernel.syntax_fns {n = 1, dest = HolKernel.dest_monop, make = HolKernel.mk_monop} "bir_init_prog" "bir_state_init";
 
 val (bir_state_is_terminated_tm,  mk_bir_state_is_terminated, dest_bir_state_is_terminated, is_bir_state_is_terminated)  = syntax_fns1 "bir_state_is_terminated";
 

--- a/src/theory/bir/bir_typing_progScript.sml
+++ b/src/theory/bir/bir_typing_progScript.sml
@@ -18,26 +18,26 @@ val bir_stmts_of_block_def = Define `bir_stmts_of_block bl =
 val bir_stmts_of_prog_def = Define `bir_stmts_of_prog (BirProgram p) =
   BIGUNION (IMAGE bir_stmts_of_block (set p))`;
 
-val bir_get_current_statement_stmts_of_prog = store_thm ("bir_get_current_statement_stmts_of_prog",
-  ``!p pc stmt. (bir_get_current_statement p pc = SOME stmt) ==>
-                stmt IN (bir_stmts_of_prog p)``,
-
-Cases >> rename1 `BirProgram p` >>
-SIMP_TAC std_ss [bir_get_current_statement_def, bir_stmts_of_prog_def,
-  IN_BIGUNION, IN_IMAGE, PULL_EXISTS, bir_stmts_of_block_def,
-  IN_INSERT, IN_IMAGE] >>
-REPEAT GEN_TAC >>
-Cases_on `(bir_get_program_block_info_by_label (BirProgram p) pc.bpc_label)` >- (
-  ASM_SIMP_TAC std_ss []
-) >>
-rename1 `_ = SOME xy` >> Cases_on `xy` >>
-rename1 `_ = SOME (i, bl)` >>
-ASM_SIMP_TAC (std_ss++boolSimps.LIFT_COND_ss) [] >>
-CASE_TAC >> STRIP_TAC >> REPEAT BasicProvers.VAR_EQ_TAC >> (
-  FULL_SIMP_TAC std_ss [bir_get_program_block_info_by_label_THM,
-    bir_stmt_t_11, bir_stmt_t_distinct] >>
-  METIS_TAC[rich_listTheory.EL_MEM]
-));
+Theorem bir_get_current_statement_stmts_of_prog:
+  !p pc stmt. (bir_get_current_statement p pc = SOME stmt) ==>
+                stmt IN (bir_stmts_of_prog p)
+Proof
+  Cases >> rename1 `BirProgram p` >>
+  SIMP_TAC std_ss [bir_get_current_statement_def, bir_stmts_of_prog_def,
+    IN_BIGUNION, IN_IMAGE, PULL_EXISTS, bir_stmts_of_block_def,
+    IN_INSERT, IN_IMAGE] >>
+  REPEAT GEN_TAC >>
+  Cases_on `(bir_get_program_block_info_by_label (BirProgram p) pc.bpc_label)` >- (
+    ASM_SIMP_TAC std_ss []
+  ) >>
+  rename1 `_ = SOME xy` >> Cases_on `xy` >>
+  rename1 `_ = SOME (i, bl)` >>
+  ASM_SIMP_TAC (std_ss++boolSimps.LIFT_COND_ss) [] >>
+  CASE_TAC >> STRIP_TAC >> REPEAT BasicProvers.VAR_EQ_TAC >> (
+    FULL_SIMP_TAC std_ss [bir_get_program_block_info_by_label_THM] >>
+    METIS_TAC[rich_listTheory.EL_MEM]
+  )
+QED
 
 
 

--- a/src/theory/bir/bir_typing_progScript.sml
+++ b/src/theory/bir/bir_typing_progScript.sml
@@ -119,6 +119,16 @@ val bir_vars_of_stmtB_def = Define `
      BIGUNION (IMAGE bir_vars_of_exp (LIST_TO_SET (ec::el)))) /\
   (bir_vars_of_stmtB (BStmt_Fence _ _) = {})`;
 
+Definition bmc_vars_of_stmtB_def:
+     bmc_vars_of_stmtB (BMCStmt_Load var exp _ _ _ _) = { var } UNION bir_varset_of_exp exp
+  /\ bmc_vars_of_stmtB (BMCStmt_Store var exp exp' _ _ _) = { var } UNION bir_varset_of_exp exp UNION bir_varset_of_exp exp'
+  /\ bmc_vars_of_stmtB (BMCStmt_Amo var exp exp' _ _) = { var } UNION bir_varset_of_exp exp UNION bir_varset_of_exp exp'
+  /\ bmc_vars_of_stmtB (BMCStmt_Assign var exp) = { var } UNION bir_varset_of_exp exp
+  /\ bmc_vars_of_stmtB (BMCStmt_Fence _ _) = {}
+  /\ bmc_vars_of_stmtB (BMCStmt_Assert exp) = bir_varset_of_exp exp
+  /\ bmc_vars_of_stmtB (BMCStmt_Assume exp) = bir_varset_of_exp exp
+End
+
 val bir_vars_of_label_exp_def = Define `
   (bir_vars_of_label_exp (BLE_Label l) = {}) /\
   (bir_vars_of_label_exp (BLE_Exp e) = bir_vars_of_exp e)`;
@@ -137,8 +147,15 @@ val bir_vars_of_block_def = Define `bir_vars_of_block bl <=>
   ((BIGUNION (IMAGE bir_vars_of_stmtB (LIST_TO_SET bl.bb_statements))) UNION
    (bir_vars_of_stmtE bl.bb_last_statement))`;
 
+val bmc_vars_of_block_def = Define `bmc_vars_of_block bl <=>
+  ((BIGUNION (IMAGE bmc_vars_of_stmtB (LIST_TO_SET bl.bb_statements))) UNION
+   (bir_vars_of_stmtE bl.bb_last_statement))`;
+
 val bir_vars_of_program_def = Define `bir_vars_of_program (BirProgram p) <=>
   (BIGUNION (IMAGE bir_vars_of_block (LIST_TO_SET p)))`;
+
+val bmc_vars_of_program_def = Define `bmc_vars_of_program (BirProgram p) <=>
+  (BIGUNION (IMAGE bmc_vars_of_block (LIST_TO_SET p)))`;
 
 val bir_vars_of_block_ALT_DEF = store_thm ("bir_vars_of_block_ALT_DEF",
   ``!bl. bir_vars_of_block bl = BIGUNION (IMAGE bir_vars_of_stmt (bir_stmts_of_block bl))``,

--- a/src/theory/tools/promising/bir_promising_wfScript.sml
+++ b/src/theory/tools/promising/bir_promising_wfScript.sml
@@ -733,7 +733,7 @@ QED
 Theorem wf_init_state:
   !cid p. well_formed cid [] $ bmc_state_init p
 Proof
-  fs[bir_programTheory.bmc_state_init_def,well_formed_def,well_formed_viewenv_def,well_formed_fwdb_def,mem_read_def,listTheory.oEL_THM,mem_get_def]
+  fs[bir_init_progTheory.bmc_state_init_def,well_formed_def,well_formed_viewenv_def,well_formed_fwdb_def,mem_read_def,listTheory.oEL_THM,mem_get_def]
 QED
 
 Definition init_def:

--- a/src/tools/scamv/symbexec/examples/test-minimal.sml
+++ b/src/tools/scamv/symbexec/examples/test-minimal.sml
@@ -147,7 +147,7 @@ val prog = ``BirProgram
 val prog2 = ``BirProgram
   [<|bb_label :=
        BL_Address_HC (Imm64 0w) "3649DFA1 (tbz w1, #9, 3bf4 <.text+0x3bf4>)";
-     bb_statements := [];
+     bb_statements := []: ('a bir_stmt_basic_t) list;
      bb_last_statement :=
        BStmt_CJmp
          (BExp_word_bit Bit32
@@ -156,7 +156,7 @@ val prog2 = ``BirProgram
          (BLE_Label (BL_Address (Imm64 15348w)))|>;
    <|bb_label :=
        BL_Address_HC (Imm64 4w) "B5010034 (cbnz x20, 2008 <.text+0x2008>)";
-     bb_statements := [];
+     bb_statements := []: ('a bir_stmt_basic_t) list;
      bb_last_statement :=
        BStmt_CJmp
          (BExp_BinPred BIExp_Equal (BExp_Den (BVar "R20" (BType_Imm Bit64)))
@@ -167,7 +167,7 @@ val prog2 = ``BirProgram
 val prog3 = ``BirProgram
   [<|bb_label :=
    BL_Address_HC (Imm64 0w) "3649DFA1 (tbz w1, #9, 3bf4 <.text+0x3bf4>)";
-   bb_statements := [];
+   bb_statements := []: ('a bir_stmt_basic_t) list;
    bb_last_statement :=
    BStmt_CJmp
        (BExp_word_bit Bit32
@@ -178,7 +178,7 @@ val prog3 = ``BirProgram
 val prog4 = ``BirProgram
   [<|bb_label :=
    BL_Address_HC (Imm64 4w) "B5010034 (cbnz x20, 2008 <.text+0x2008>)";
-   bb_statements := [];
+   bb_statements := []: ('a bir_stmt_basic_t) list;
    bb_last_statement :=
    BStmt_CJmp
        (BExp_BinPred BIExp_Equal (BExp_Den (BVar "R20" (BType_Imm Bit64)))
@@ -197,7 +197,7 @@ val leafs_prog4 = leafs_of prog4;
 val prog5 = ``BirProgram
   [<|bb_label :=
    BL_Address_HC (Imm64 4w) "B5010034 (cbnz x20, 2008 <.text+0x2008>)";
-   bb_statements := [];
+   bb_statements := [] : ('a bir_stmt_basic_t) list;
    bb_last_statement :=
    BStmt_CJmp
        (BExp_BinPred BIExp_Equal (BExp_Den (BVar "R20*" (BType_Imm Bit64)))

--- a/src/tools/wp/bir_wpLib.sml
+++ b/src/tools/wp/bir_wpLib.sml
@@ -295,12 +295,13 @@ open bir_inst_liftingHelpersLib;
 
       (* FIXME: This seems to take some time, is that normal? *)
       val wps_eval_restrict_consts = !bir_wp_comp_wps_iter_step2_consts;
-      val prog_obs_ty = (hd o snd o dest_type o type_of) program;
+      val prog_obs_ty = (hd o snd o dest_type o hd o snd o dest_type o type_of) program;
 
       val bir_wp_exec_of_block_eval_thm =
         ((computeLib.RESTR_EVAL_CONV wps_eval_restrict_consts) THENC
          (REWRITE_CONV [pred_setTheory.IN_APP]) THENC
          (computeLib.RESTR_EVAL_CONV wps_eval_restrict_consts))
+
           (list_mk_comb
             (* TODO: Add to bir_wpSyntax *)
             (inst [Type `:'a` |-> prog_obs_ty] ``bir_wp_exec_of_block:'a bir_program_t ->


### PR DESCRIPTION
Somewhat makes output of earlier function `bir_get_stmt` into BIR multicore syntax.
Moves the init state definitions from `bir_programTheory` to a theory of its own.